### PR TITLE
Add Tkinter GUI and share option helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ own legal backups of the games you wish to randomize.
    Use the same command with Generation II ROMs; the tool will automatically
    detect the generation.
 
+### Launching the graphical interface
+
+Prefer a windowed experience? Install the project and run:
+
+```bash
+pokemon-randomizer-gui
+```
+
+The GUI includes browse buttons for the ROM you want to randomize and the
+location where the modified ROM should be written. You can optionally supply a
+seed, toggle legendary encounters, or disable wild encounter randomization.
+Status messages appear at the bottom of the window so you immediately know when
+the process succeeds or if the provided paths need attention.
+
 ### Useful command line flags
 
 * `--seed 12345` – specify a seed for reproducible results. Any string or

--- a/pokemon_randomizer/cli.py
+++ b/pokemon_randomizer/cli.py
@@ -7,7 +7,8 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-from .core import RandomizationOptions, randomize_rom
+from .core import randomize_rom
+from .options import build_options, resolve_paths
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -46,20 +47,21 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    options = RandomizationOptions(
+    rom_path, output_path = resolve_paths(args.rom, args.output)
+    options = build_options(
         seed=args.seed,
-        randomize_wild=not args.no_wild,
         allow_legendaries=args.allow_legendaries,
+        disable_wild=args.no_wild,
     )
 
     try:
-        info = randomize_rom(args.rom, args.output, options)
+        info = randomize_rom(rom_path, output_path, options)
     except FileNotFoundError as exc:
         parser.error(str(exc))
     except ValueError as exc:
         parser.error(str(exc))
 
-    if not args.no_wild:
+    if options.randomize_wild:
         feature_summary = "wild encounters"
     else:
         feature_summary = "no features"

--- a/pokemon_randomizer/gui.py
+++ b/pokemon_randomizer/gui.py
@@ -1,0 +1,160 @@
+"""Graphical interface for the Pokémon randomizer."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, ttk
+
+from .core import randomize_rom
+from .options import build_options, resolve_paths
+
+
+def main() -> None:
+    """Launch the graphical interface."""
+
+    root = tk.Tk()
+    root.title("Pokémon Randomizer")
+    root.resizable(False, False)
+
+    style = ttk.Style(root)
+    style.configure("Status.TLabel", foreground=style.lookup("TLabel", "foreground"))
+    style.configure("Error.TLabel", foreground="#b00020")
+    style.configure("Success.TLabel", foreground="#006400")
+
+    rom_var = tk.StringVar()
+    output_var = tk.StringVar()
+    seed_var = tk.StringVar()
+    allow_legendaries_var = tk.BooleanVar()
+    disable_wild_var = tk.BooleanVar()
+    status_var = tk.StringVar()
+
+    mainframe = ttk.Frame(root, padding="12 12 12 12")
+    mainframe.grid(column=0, row=0, sticky="nsew")
+    mainframe.columnconfigure(1, weight=1)
+
+    ttk.Label(mainframe, text="ROM path:").grid(column=0, row=0, sticky="w")
+    rom_entry = ttk.Entry(mainframe, textvariable=rom_var, width=45)
+    rom_entry.grid(column=1, row=0, sticky="ew")
+
+    def choose_rom() -> None:
+        filename = filedialog.askopenfilename(
+            title="Select a Pokémon ROM",
+            filetypes=[
+                ("Game Boy / Game Boy Color ROMs", "*.gb *.gbc *.gbx"),
+                ("All files", "*.*"),
+            ],
+        )
+        if filename:
+            rom_var.set(filename)
+
+    ttk.Button(mainframe, text="Browse…", command=choose_rom).grid(column=2, row=0, sticky="ew")
+
+    ttk.Label(mainframe, text="Output path:").grid(column=0, row=1, sticky="w")
+    output_entry = ttk.Entry(mainframe, textvariable=output_var, width=45)
+    output_entry.grid(column=1, row=1, sticky="ew")
+
+    def choose_output() -> None:
+        initialfile = ""
+        rom_value = rom_var.get()
+        if rom_value:
+            initialfile = rom_value
+        filename = filedialog.asksaveasfilename(
+            title="Save randomized ROM",
+            defaultextension=".gbc",
+            filetypes=[
+                ("Game Boy / Game Boy Color ROMs", "*.gb *.gbc *.gbx"),
+                ("All files", "*.*"),
+            ],
+            initialfile=initialfile,
+        )
+        if filename:
+            output_var.set(filename)
+
+    ttk.Button(mainframe, text="Browse…", command=choose_output).grid(column=2, row=1, sticky="ew")
+
+    ttk.Label(mainframe, text="Seed (optional):").grid(column=0, row=2, sticky="w")
+    seed_entry = ttk.Entry(mainframe, textvariable=seed_var, width=45)
+    seed_entry.grid(column=1, row=2, sticky="ew")
+
+    allow_legendaries_check = ttk.Checkbutton(
+        mainframe,
+        text="Allow legendaries",
+        variable=allow_legendaries_var,
+    )
+    allow_legendaries_check.grid(column=1, row=3, sticky="w")
+
+    disable_wild_check = ttk.Checkbutton(
+        mainframe,
+        text="Disable wild encounters",
+        variable=disable_wild_var,
+    )
+    disable_wild_check.grid(column=1, row=4, sticky="w")
+
+    status_label = ttk.Label(mainframe, textvariable=status_var, style="Status.TLabel", wraplength=420)
+    status_label.grid(column=0, row=6, columnspan=3, sticky="ew")
+
+    def set_status(message: str, *, error: bool = False) -> None:
+        status_var.set(message)
+        if not message:
+            status_label.configure(style="Status.TLabel")
+        elif error:
+            status_label.configure(style="Error.TLabel")
+        else:
+            status_label.configure(style="Success.TLabel")
+
+    def run_randomization(event: object | None = None) -> None:
+        set_status("")
+        rom_value = rom_var.get().strip()
+        output_value = output_var.get().strip()
+
+        if not rom_value:
+            set_status("Please choose a ROM file to randomize.", error=True)
+            rom_entry.focus_set()
+            return
+        if not output_value:
+            set_status("Please choose where to save the randomized ROM.", error=True)
+            output_entry.focus_set()
+            return
+
+        options = build_options(
+            seed=seed_var.get(),
+            allow_legendaries=allow_legendaries_var.get(),
+            disable_wild=disable_wild_var.get(),
+        )
+        rom_path, output_path = resolve_paths(rom_value, output_value)
+
+        try:
+            info = randomize_rom(rom_path, output_path, options)
+        except FileNotFoundError as exc:
+            set_status(str(exc), error=True)
+        except ValueError as exc:
+            set_status(str(exc), error=True)
+        except Exception as exc:  # pragma: no cover - safety net for GUI usage
+            set_status(f"Unexpected error: {exc}", error=True)
+        else:
+            feature_summary = "wild encounters" if options.randomize_wild else "no features"
+            seed_display = str(options.seed) if options.seed is not None else "None"
+            set_status(
+                "Randomized {title} (Generation {generation}) with seed {seed}. Modified features: {features}.".format(
+                    title=info.title,
+                    generation=info.generation,
+                    seed=seed_display,
+                    features=feature_summary,
+                ),
+                error=False,
+            )
+
+    randomize_button = ttk.Button(mainframe, text="Randomize", command=run_randomization)
+    randomize_button.grid(column=1, row=5, sticky="e")
+
+    for child in mainframe.winfo_children():
+        child.grid_configure(padx=4, pady=4)
+
+    rom_entry.focus_set()
+    root.bind("<Return>", run_randomization)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    main()

--- a/pokemon_randomizer/options.py
+++ b/pokemon_randomizer/options.py
@@ -1,0 +1,51 @@
+"""Shared helpers for building randomization options from user input."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .core import RandomizationOptions
+
+
+def normalize_seed(seed: str | int | None) -> str | int | None:
+    """Return a normalized seed value.
+
+    Empty strings are converted to ``None`` so optional UI elements can pass
+    blank values without additional checks.
+    """
+
+    if seed is None:
+        return None
+    if isinstance(seed, str):
+        seed = seed.strip()
+        if not seed:
+            return None
+    return seed
+
+
+def build_options(
+    *,
+    seed: str | int | None,
+    allow_legendaries: bool,
+    disable_wild: bool,
+) -> RandomizationOptions:
+    """Create :class:`RandomizationOptions` from raw flag values."""
+
+    normalized_seed = normalize_seed(seed)
+    return RandomizationOptions(
+        seed=normalized_seed,
+        randomize_wild=not disable_wild,
+        allow_legendaries=allow_legendaries,
+    )
+
+
+def resolve_paths(rom: str | Path, output: str | Path) -> tuple[Path, Path]:
+    """Normalize input and output paths.
+
+    ``Path`` objects passed by the CLI are accepted, while strings coming from
+    the GUI are expanded to allow user shortcuts such as ``~``.
+    """
+
+    rom_path = Path(rom).expanduser()
+    output_path = Path(output).expanduser()
+    return rom_path, output_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 
 [project.scripts]
 pokemon-randomizer = "pokemon_randomizer.cli:main"
+pokemon-randomizer-gui = "pokemon_randomizer.gui:main"
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
## Summary
- add a Tkinter-based graphical interface wired to the existing randomizer logic
- extract reusable helpers so the CLI and GUI share option normalization
- document the GUI and register a console entry point for launching it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1dc2078c83339ebd2e679bc2ba7d