### PR TITLE
Add PyInstaller spec and Windows packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,38 @@ seed, toggle legendary encounters, or disable wild encounter randomization.
 Status messages appear at the bottom of the window so you immediately know when
 the process succeeds or if the provided paths need attention.
 
+## Windows executable
+
+Want to distribute the GUI without requiring Python on the target machine? Use
+PyInstaller to build a standalone Windows executable:
+
+1. From a Windows command prompt or PowerShell session install the project and
+   PyInstaller into the same environment:
+
+   ```powershell
+   python -m pip install -e . pyinstaller
+   ```
+
+2. Generate the executable with a single command:
+
+   ```powershell
+   python build\tools\build_windows_exe.py
+   ```
+
+   (If you prefer, you can run `python -m PyInstaller build\tools\pokemon_randomizer_gui.spec`
+   directly.) PyInstaller uses a spec file configured to launch the GUI's
+   `main()` entry point without a console window and bundles the required
+   Tkinter resources.
+
+3. After the command finishes, open the `dist\PokemonRandomizerGui` directory
+   and double-click `PokemonRandomizerGui.exe`.
+
+To verify the packaged app, launch the executable, select a clean Generation I
+or II ROM, choose an output path for the randomized file, and click **Randomize**.
+The status bar should report success once the ROM has been processed. You can
+confirm the end-to-end flow by opening the randomized ROM in your preferred
+emulator and observing the new encounter tables.
+
 ### Useful command line flags
 
 * `--seed 12345` – specify a seed for reproducible results. Any string or

--- a/build/tools/build_windows_exe.py
+++ b/build/tools/build_windows_exe.py
@@ -1,0 +1,25 @@
+"""Helper for building the Windows GUI executable with PyInstaller."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec_path = Path(__file__).resolve().with_name("pokemon_randomizer_gui.spec")
+
+    command = [sys.executable, "-m", "PyInstaller", str(spec_path)]
+
+    print("Running:", " ".join(command))
+    subprocess.run(command, check=True, cwd=repo_root)
+
+    dist_dir = repo_root / "dist" / "PokemonRandomizerGui"
+    exe_path = dist_dir / "PokemonRandomizerGui.exe"
+    print(f"\nBuild complete. Check {exe_path} for the generated executable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/build/tools/pokemon_randomizer_gui.spec
+++ b/build/tools/pokemon_randomizer_gui.spec
@@ -1,0 +1,60 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+block_cipher = None
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+tk_datas = collect_data_files("tkinter")
+
+a = Analysis(
+    [str(PROJECT_ROOT / "pokemon_randomizer" / "gui.py")],
+    pathex=[str(PROJECT_ROOT)],
+    binaries=[],
+    datas=tk_datas,
+    hiddenimports=collect_submodules("pokemon_randomizer"),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="PokemonRandomizerGui",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=[],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="PokemonRandomizerGui",
+)


### PR DESCRIPTION
## Summary
- add a PyInstaller spec that builds the GUI entry point without a console and bundles Tk resources
- provide a helper script for invoking the spec from Windows
- document how to build and validate the packaged Windows executable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc201adaac8333b30d6a202a168409